### PR TITLE
BsonKnownTypes Entity Mapping Support

### DIFF
--- a/MongoFramework.Tests/Infrastructure/Mapping/Processors/BsonKnowTypesProcessorTests.cs
+++ b/MongoFramework.Tests/Infrastructure/Mapping/Processors/BsonKnowTypesProcessorTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoFramework.Infrastructure.Mapping.Processors;
+
+namespace MongoFramework.Tests.Infrastructure.Mapping.Processors
+{
+	[TestClass]
+	public class BsonKnowTypesProcessorTests : TestBase
+	{
+		[BsonKnownTypes(typeof(KnownTypesChildModel))]
+		class KnownTypesBaseModel
+		{
+			public string Id { get; set; }
+		}
+
+		class KnownTypesChildModel : KnownTypesBaseModel
+		{
+
+		}
+
+		class UnknownTypesBaseModel
+		{
+
+		}
+
+		class UnknownTypesChildModel : UnknownTypesBaseModel
+		{
+
+		}
+
+		[TestMethod]
+		public void WithAttribute()
+		{
+			var processor = new BsonKnownTypesProcessor();
+			var classMap = new BsonClassMap<KnownTypesBaseModel>();
+			Assert.IsFalse(BsonClassMap.IsClassMapRegistered(typeof(KnownTypesChildModel)));
+			processor.ApplyMapping(typeof(KnownTypesBaseModel), classMap);
+			Assert.IsTrue(BsonClassMap.IsClassMapRegistered(typeof(KnownTypesChildModel)));
+		}
+
+		[TestMethod]
+		public void WithoutAttribute()
+		{
+			var processor = new BsonKnownTypesProcessor();
+			var classMap = new BsonClassMap<UnknownTypesBaseModel>();
+			Assert.IsFalse(BsonClassMap.IsClassMapRegistered(typeof(UnknownTypesChildModel)));
+			processor.ApplyMapping(typeof(UnknownTypesBaseModel), classMap);
+			Assert.IsFalse(BsonClassMap.IsClassMapRegistered(typeof(UnknownTypesChildModel)));
+		}
+	}
+}

--- a/MongoFramework/Infrastructure/Mapping/DefaultMappingPack.cs
+++ b/MongoFramework/Infrastructure/Mapping/DefaultMappingPack.cs
@@ -17,7 +17,8 @@ namespace MongoFramework.Infrastructure.Mapping
 				new NestedPropertyProcessor(),
 				new ExtraElementsProcessor(),
 				new NavigationPropertyProcessor(),
-				new TypeDiscoveryProcessor()
+				new TypeDiscoveryProcessor(),
+				new BsonKnownTypesProcessor()
 			};
 		}
 

--- a/MongoFramework/Infrastructure/Mapping/Processors/BsonKnownTypesProcessor.cs
+++ b/MongoFramework/Infrastructure/Mapping/Processors/BsonKnownTypesProcessor.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace MongoFramework.Infrastructure.Mapping.Processors
+{
+	public class BsonKnownTypesProcessor : IMappingProcessor
+	{
+		public void ApplyMapping(Type entityType, BsonClassMap classMap)
+		{
+			var bsonKnownTypesAttribute = entityType.GetCustomAttribute<BsonKnownTypesAttribute>();
+			if (bsonKnownTypesAttribute != null)
+			{
+				foreach (var type in bsonKnownTypesAttribute.KnownTypes)
+				{
+					new EntityMapper(type);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds support for the `BsonKnownTypesAttribute` and running that through the `EntityMapper`. See issue #8.