### PR TITLE
WIP: Entity Relationship Refactor

### DIFF
--- a/src/MongoFramework/Infrastructure/Commands/AddEntityCommand.cs
+++ b/src/MongoFramework/Infrastructure/Commands/AddEntityCommand.cs
@@ -7,16 +7,16 @@ namespace MongoFramework.Infrastructure.Commands
 {
 	public class AddEntityCommand<TEntity> : IWriteCommand<TEntity> where TEntity : class
 	{
-		private EntityEntry<TEntity> EntityEntry { get; }
+		private EntityEntry EntityEntry { get; }
 
-		public AddEntityCommand(EntityEntry<TEntity> entityEntry)
+		public AddEntityCommand(EntityEntry entityEntry)
 		{
 			EntityEntry = entityEntry;
 		}
 
 		public IEnumerable<WriteModel<TEntity>> GetModel()
 		{
-			yield return new InsertOneModel<TEntity>(EntityEntry.Entity);
+			yield return new InsertOneModel<TEntity>(EntityEntry.Entity as TEntity);
 		}
 	}
 }

--- a/src/MongoFramework/Infrastructure/Commands/RemoveEntityCommand.cs
+++ b/src/MongoFramework/Infrastructure/Commands/RemoveEntityCommand.cs
@@ -9,9 +9,9 @@ namespace MongoFramework.Infrastructure.Commands
 {
 	public class RemoveEntityCommand<TEntity> : IWriteCommand<TEntity> where TEntity : class
 	{
-		private EntityEntry<TEntity> EntityEntry { get; }
+		private EntityEntry EntityEntry { get; }
 
-		public RemoveEntityCommand(EntityEntry<TEntity> entityEntry)
+		public RemoveEntityCommand(EntityEntry entityEntry)
 		{
 			EntityEntry = entityEntry;
 		}
@@ -19,7 +19,7 @@ namespace MongoFramework.Infrastructure.Commands
 		public IEnumerable<WriteModel<TEntity>> GetModel()
 		{
 			var definition = EntityMapping.GetOrCreateDefinition(typeof(TEntity));
-			yield return new DeleteOneModel<TEntity>(definition.CreateIdFilterFromEntity(EntityEntry.Entity));
+			yield return new DeleteOneModel<TEntity>(definition.CreateIdFilterFromEntity(EntityEntry.Entity as TEntity));
 		}
 	}
 }

--- a/src/MongoFramework/Infrastructure/Commands/UpdateEntityCommand.cs
+++ b/src/MongoFramework/Infrastructure/Commands/UpdateEntityCommand.cs
@@ -9,9 +9,9 @@ namespace MongoFramework.Infrastructure.Commands
 {
 	public class UpdateEntityCommand<TEntity> : IWriteCommand<TEntity> where TEntity : class
 	{
-		private EntityEntry<TEntity> EntityEntry { get; }
+		private EntityEntry EntityEntry { get; }
 
-		public UpdateEntityCommand(EntityEntry<TEntity> entityEntry)
+		public UpdateEntityCommand(EntityEntry entityEntry)
 		{
 			EntityEntry = entityEntry;
 		}
@@ -25,7 +25,7 @@ namespace MongoFramework.Infrastructure.Commands
 			//This is primarily to work around a mutation that may set an entity to its default state.
 			if (updateDefintion.HasChanges())
 			{
-				yield return new UpdateOneModel<TEntity>(definition.CreateIdFilterFromEntity(EntityEntry.Entity), updateDefintion);
+				yield return new UpdateOneModel<TEntity>(definition.CreateIdFilterFromEntity(EntityEntry.Entity as TEntity), updateDefintion);
 			}
 		}
 	}

--- a/src/MongoFramework/Infrastructure/EntityBucketStagingCollection.cs
+++ b/src/MongoFramework/Infrastructure/EntityBucketStagingCollection.cs
@@ -48,7 +48,7 @@ namespace MongoFramework.Infrastructure
 			return queryable;
 		}
 
-		public IEnumerable<EntityEntry<EntityBucket<TGroup, TSubEntity>>> GetEntries()
+		public IEnumerable<EntityEntry> GetEntries()
 		{
 			foreach (var grouping in SubEntityStaging)
 			{
@@ -71,7 +71,7 @@ namespace MongoFramework.Infrastructure
 						bucket.Items.AddRange(sliceEntities);
 						bucket.ItemCount += sliceSize;
 
-						yield return new EntityEntry<EntityBucket<TGroup, TSubEntity>>(bucket, EntityEntryState.Updated);
+						yield return new EntityEntry(bucket, EntityEntryState.Updated);
 
 						sliceAt += sliceSize;
 						remainingEntitiesCount -= sliceSize;
@@ -85,7 +85,7 @@ namespace MongoFramework.Infrastructure
 					var sliceSize = Math.Min(BucketSize, remainingEntitiesCount);
 					var sliceEntities = entityList.Skip(sliceAt).Take(sliceSize).ToList();
 
-					yield return new EntityEntry<EntityBucket<TGroup, TSubEntity>>(new EntityBucket<TGroup, TSubEntity>
+					yield return new EntityEntry(new EntityBucket<TGroup, TSubEntity>
 					{
 						Group = grouping.Key,
 						Index = currentBucketIndex,
@@ -102,7 +102,7 @@ namespace MongoFramework.Infrastructure
 			}
 		}
 
-		public EntityEntry<EntityBucket<TGroup, TSubEntity>> GetEntry(EntityBucket<TGroup, TSubEntity> entity)
+		public EntityEntry GetEntry(EntityBucket<TGroup, TSubEntity> entity)
 		{
 			throw new NotImplementedException();
 		}

--- a/src/MongoFramework/Infrastructure/EntityCollection.cs
+++ b/src/MongoFramework/Infrastructure/EntityCollection.cs
@@ -8,7 +8,7 @@ namespace MongoFramework.Infrastructure
 {
 	public class EntityCollection<TEntity> : IEntityCollection<TEntity> where TEntity : class
 	{
-		protected List<EntityEntry<TEntity>> Entries { get; } = new List<EntityEntry<TEntity>>();
+		protected List<EntityEntry> Entries { get; } = new List<EntityEntry>();
 
 		private IEntityDefinition EntityDefinition { get; }
 
@@ -21,7 +21,7 @@ namespace MongoFramework.Infrastructure
 
 		public bool IsReadOnly => false;
 
-		public EntityEntry<TEntity> GetEntry(TEntity entity)
+		public EntityEntry GetEntry(TEntity entity)
 		{
 			var entityId = EntityDefinition.GetIdValue(entity);
 			var defaultIdValue = EntityDefinition.GetDefaultId();
@@ -45,7 +45,7 @@ namespace MongoFramework.Infrastructure
 			return null;
 		}
 
-		public IEnumerable<EntityEntry<TEntity>> GetEntries()
+		public IEnumerable<EntityEntry> GetEntries()
 		{
 			return Entries;
 		}
@@ -62,12 +62,12 @@ namespace MongoFramework.Infrastructure
 				else
 				{
 					Entries.Remove(entry);
-					Entries.Add(new EntityEntry<TEntity>(entity, state));
+					Entries.Add(new EntityEntry(entity, state));
 				}
 			}
 			else
 			{
-				Entries.Add(new EntityEntry<TEntity>(entity, state));
+				Entries.Add(new EntityEntry(entity, state));
 			}
 		}
 
@@ -120,7 +120,7 @@ namespace MongoFramework.Infrastructure
 
 			for (var i = 0; i < Count; i++)
 			{
-				array[i + arrayIndex] = Entries[i].Entity;
+				array[i + arrayIndex] = Entries[i].Entity as TEntity;
 			}
 		}
 
@@ -131,7 +131,7 @@ namespace MongoFramework.Infrastructure
 			{
 				while (enumerator.MoveNext())
 				{
-					yield return enumerator.Current;
+					yield return enumerator.Current as TEntity;
 				}
 			}
 		}

--- a/src/MongoFramework/Infrastructure/EntityCommandBuilder.cs
+++ b/src/MongoFramework/Infrastructure/EntityCommandBuilder.cs
@@ -8,7 +8,7 @@ namespace MongoFramework.Infrastructure
 {
 	public static class EntityCommandBuilder<TEntity> where TEntity : class
 	{
-		public static IWriteCommand<TEntity> CreateCommand(EntityEntry<TEntity> entityEntry)
+		public static IWriteCommand<TEntity> CreateCommand(EntityEntry entityEntry)
 		{
 			if (entityEntry.State == EntityEntryState.Added)
 			{

--- a/src/MongoFramework/Infrastructure/EntityEntry.cs
+++ b/src/MongoFramework/Infrastructure/EntityEntry.cs
@@ -2,10 +2,10 @@
 
 namespace MongoFramework.Infrastructure
 {
-	public class EntityEntry<TEntity> where TEntity : class
+	public class EntityEntry
 	{
 		/// <summary>
-		/// The state of the entity in this <see cref="EntityEntry{TEntity}"/> object.
+		/// The state of the entity in this <see cref="EntityEntry"/> object.
 		/// </summary>
 		public EntityEntryState State { get; set; }
 
@@ -17,14 +17,14 @@ namespace MongoFramework.Infrastructure
 		/// <summary>
 		/// The entity that forms this <see cref="EntityEntry{TEntity}"/> object.
 		/// </summary>
-		public TEntity Entity { get; private set; }
+		public object Entity { get; private set; }
 
 		/// <summary>
-		/// Creates a new <see cref="EntityEntry{TEntity}"/> with the specified entity and state information.
+		/// Creates a new <see cref="EntityEntry"/> with the specified entity and state information.
 		/// </summary>
 		/// <param name="entity"></param>
 		/// <param name="state"></param>
-		public EntityEntry(TEntity entity, EntityEntryState state)
+		public EntityEntry(object entity, EntityEntryState state)
 		{
 			State = state;
 			Entity = entity;
@@ -47,7 +47,7 @@ namespace MongoFramework.Infrastructure
 		/// Update the original values to reflect the state of the provided entity.
 		/// </summary>
 		/// <param name="entity"></param>
-		public void Refresh(TEntity entity)
+		public void Refresh(object entity)
 		{
 			OriginalValues = entity.ToBsonDocument();
 			State = this.HasChanges() ? EntityEntryState.Updated : EntityEntryState.NoChanges;

--- a/src/MongoFramework/Infrastructure/EntityEntryExtensions.cs
+++ b/src/MongoFramework/Infrastructure/EntityEntryExtensions.cs
@@ -8,7 +8,7 @@ namespace MongoFramework.Infrastructure
 		/// Whether there are any changes between the original and current values of the entity.
 		/// </summary>
 		/// <returns></returns>
-		public static bool HasChanges<TEntity>(this EntityEntry<TEntity> entry) where TEntity : class
+		public static bool HasChanges(this EntityEntry entry)
 		{
 			return BsonDiff.HasDifferences(entry.OriginalValues, entry.CurrentValues);
 		}

--- a/src/MongoFramework/Infrastructure/EntityNavigationCollection.cs
+++ b/src/MongoFramework/Infrastructure/EntityNavigationCollection.cs
@@ -89,7 +89,7 @@ namespace MongoFramework.Infrastructure
 			{
 				while (enumerator.MoveNext())
 				{
-					yield return enumerator.Current;
+					yield return enumerator.Current as TEntity;
 				}
 			}
 

--- a/src/MongoFramework/Infrastructure/EntityWriterPipeline.cs
+++ b/src/MongoFramework/Infrastructure/EntityWriterPipeline.cs
@@ -88,7 +88,7 @@ namespace MongoFramework.Infrastructure
 					}
 					else if (entry.State == EntityEntryState.Deleted)
 					{
-						collection.Remove(entry.Entity);
+						collection.Remove(entry.Entity as TEntity);
 					}
 				}
 			}
@@ -104,11 +104,11 @@ namespace MongoFramework.Infrastructure
 				{
 					if (entry.State == EntityEntryState.Added)
 					{
-						EntityMutation<TEntity>.MutateEntity(entry.Entity, MutatorType.Insert, Connection);
+						EntityMutation<TEntity>.MutateEntity(entry.Entity as TEntity, MutatorType.Insert, Connection);
 					}
 					else if (entry.State == EntityEntryState.Updated)
 					{
-						EntityMutation<TEntity>.MutateEntity(entry.Entity, MutatorType.Update, Connection);
+						EntityMutation<TEntity>.MutateEntity(entry.Entity as TEntity, MutatorType.Update, Connection);
 					}
 
 					var validationContext = new ValidationContext(entry.Entity);

--- a/src/MongoFramework/Infrastructure/IEntityCollection.cs
+++ b/src/MongoFramework/Infrastructure/IEntityCollection.cs
@@ -4,8 +4,8 @@ namespace MongoFramework.Infrastructure
 {
 	public interface IEntityCollectionBase<TEntity> where TEntity : class
 	{
-		EntityEntry<TEntity> GetEntry(TEntity entity);
-		IEnumerable<EntityEntry<TEntity>> GetEntries();
+		EntityEntry GetEntry(TEntity entity);
+		IEnumerable<EntityEntry> GetEntries();
 		void Update(TEntity entity, EntityEntryState state);
 		bool Remove(TEntity entity);
 	}

--- a/tests/MongoFramework.Tests/Infrastructure/Commands/AddEntityCommandTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/Commands/AddEntityCommandTests.cs
@@ -31,7 +31,7 @@ namespace MongoFramework.Tests.Infrastructure.Commands
 
 			writer.Write(new[]
 			{
-				new AddEntityCommand<TestModel>(new EntityEntry<TestModel>(entity, EntityEntryState.Added))
+				new AddEntityCommand<TestModel>(new EntityEntry(entity, EntityEntryState.Added))
 			});
 
 			Assert.IsNotNull(entity.Id);

--- a/tests/MongoFramework.Tests/Infrastructure/Commands/RemoveEntityByIdCommandTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/Commands/RemoveEntityByIdCommandTests.cs
@@ -32,7 +32,7 @@ namespace MongoFramework.Tests.Infrastructure.Commands
 
 			writer.Write(new[]
 			{
-				new AddEntityCommand<TestModel>(new EntityEntry<TestModel>(entity, EntityEntryState.Added))
+				new AddEntityCommand<TestModel>(new EntityEntry(entity, EntityEntryState.Added))
 			});
 
 			writer.Write(new[]

--- a/tests/MongoFramework.Tests/Infrastructure/Commands/RemoveEntityCommandTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/Commands/RemoveEntityCommandTests.cs
@@ -32,12 +32,12 @@ namespace MongoFramework.Tests.Infrastructure.Commands
 
 			writer.Write(new[]
 			{
-				new AddEntityCommand<TestModel>(new EntityEntry<TestModel>(entity, EntityEntryState.Added))
+				new AddEntityCommand<TestModel>(new EntityEntry(entity, EntityEntryState.Added))
 			});
 
 			writer.Write(new[]
 			{
-				new RemoveEntityCommand<TestModel>(new EntityEntry<TestModel>(entity, EntityEntryState.Deleted))
+				new RemoveEntityCommand<TestModel>(new EntityEntry(entity, EntityEntryState.Deleted))
 			});
 
 			var dbEntity = reader.AsQueryable().Where(e => e.Id == entity.Id).FirstOrDefault();

--- a/tests/MongoFramework.Tests/Infrastructure/Commands/UpdateEntityCommandTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/Commands/UpdateEntityCommandTests.cs
@@ -32,7 +32,7 @@ namespace MongoFramework.Tests.Infrastructure.Commands
 
 			writer.Write(new[]
 			{
-				new AddEntityCommand<TestModel>(new EntityEntry<TestModel>(entity, EntityEntryState.Added))
+				new AddEntityCommand<TestModel>(new EntityEntry(entity, EntityEntryState.Added))
 			});
 
 			var updatedEntity = new TestModel
@@ -43,7 +43,7 @@ namespace MongoFramework.Tests.Infrastructure.Commands
 
 			writer.Write(new[]
 			{
-				new UpdateEntityCommand<TestModel>(new EntityEntry<TestModel>(updatedEntity, EntityEntryState.Updated))
+				new UpdateEntityCommand<TestModel>(new EntityEntry(updatedEntity, EntityEntryState.Updated))
 			});
 
 			var dbEntity = reader.AsQueryable().Where(e => e.Id == entity.Id).FirstOrDefault();

--- a/tests/MongoFramework.Tests/Infrastructure/EntityCollectionTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/EntityCollectionTests.cs
@@ -47,7 +47,7 @@ namespace MongoFramework.Tests.Infrastructure
 			entityCollection.Update(updatedEntity, EntityEntryState.Updated);
 			Assert.IsFalse(entityCollection.GetEntries().Any(e => e.Entity == entity));
 			Assert.IsTrue(entityCollection.GetEntries()
-				.Any(e => e.Entity == updatedEntity && e.Entity.Title == "DbEntityCollectionTests.UpdateExistingEntryWithId-2"));
+				.Any(e => e.Entity == updatedEntity && (e.Entity as EntityCollectionModel).Title == "DbEntityCollectionTests.UpdateExistingEntryWithId-2"));
 		}
 
 		[TestMethod]

--- a/tests/MongoFramework.Tests/Infrastructure/EntityWriterPipelineTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/EntityWriterPipelineTests.cs
@@ -79,7 +79,7 @@ namespace MongoFramework.Tests.Infrastructure
 				Title = "EntityWriterPipelineTests.WriteFromCollection"
 			};
 			var command = EntityCommandBuilder<TestModel>.CreateCommand(
-				new EntityEntry<TestModel>(entity, EntityEntryState.Added)
+				new EntityEntry(entity, EntityEntryState.Added)
 			);
 
 			pipeline.StageCommand(command);


### PR DESCRIPTION
Entity Relationships currently are not implemented very well:
- You can't track changes to single entity relationships (requires the full write)
- You can't delete relationships by nullifying the navigation property
- If multiple entities have the same relationship to another entity, it isn't smart enough to share a reference
- Similar to point 3, if you have the same related entity across multiple collections, each will compete when saving the entity

All of these points are pretty crap.

To address the issue, a number of changes are required with the most major being that there needs to be a central "collection" shared between data contexts and DB sets. This central collection would allow entities from multiple collections to reference the same instance of a related entity. It would also allow easier tracking of changes and potentially an easier method of support transactions.

This is a big change though - currently `MongoDbSet` can be run independently of a context. While it still might be possible, this will tie it much closer to the context than before.

Part of this change will see there being a new `Set<TEntity>()` method available on the context, similar to Entity Framework, which basically references an internal DB set. This method would be used to initialise the properties on the inherited context.

Much of the code that exists now will remain and will still be tied to generics (`TEntity`) however some pieces like `EntityEntry` likely need to change.