### PR TITLE
Type discovery serializer extended for all object-types

### DIFF
--- a/src/MongoFramework/Infrastructure/Mapping/Processors/TypeDiscoveryProcessor.cs
+++ b/src/MongoFramework/Infrastructure/Mapping/Processors/TypeDiscoveryProcessor.cs
@@ -12,8 +12,7 @@ namespace MongoFramework.Infrastructure.Mapping.Processors
 
 		public void ApplyMapping(IEntityDefinition definition, BsonClassMap classMap)
 		{
-			var entityType = definition.EntityType;
-			if (!ProviderAdded && entityType.GetCustomAttribute<RuntimeTypeDiscoveryAttribute>() != null)
+			if (!ProviderAdded)
 			{
 				ProviderAdded = true;
 				BsonSerializer.RegisterSerializationProvider(TypeDiscoverySerializationProvider.Instance);

--- a/src/MongoFramework/Infrastructure/Serialization/TypeDiscoverySerializationProvider.cs
+++ b/src/MongoFramework/Infrastructure/Serialization/TypeDiscoverySerializationProvider.cs
@@ -19,7 +19,7 @@ namespace MongoFramework.Infrastructure.Serialization
 				throw new ArgumentNullException(nameof(type));
 			}
 
-			if (Enabled && type.GetCustomAttribute<RuntimeTypeDiscoveryAttribute>() != null)
+			if (Enabled && (type.GetCustomAttribute<RuntimeTypeDiscoveryAttribute>() != null || type == typeof(object)))
 			{
 				var serializerType = typeof(TypeDiscoverySerializer<>).MakeGenericType(type);
 				return (IBsonSerializer)Activator.CreateInstance(serializerType);

--- a/tests/MongoFramework.Tests/TestBase.cs
+++ b/tests/MongoFramework.Tests/TestBase.cs
@@ -3,6 +3,7 @@ using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using MongoFramework.Infrastructure.Mapping;
+using MongoFramework.Infrastructure.Serialization;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -20,6 +21,8 @@ namespace MongoFramework.Tests
 
 			EntityMapping.RemoveAllMappingProcessors();
 			EntityMapping.AddMappingProcessors(DefaultMappingPack.Instance.Processors);
+
+			TypeDiscovery.ClearCache();
 		}
 
 		private static void ResetMongoDbDriver()


### PR DESCRIPTION
Previously, you needed to specify the `RuntimeTypeDiscoveryAttribute` on the class for type discovery to do anything. This PR extends type discovery for any properties on an object of type `Object`.

For example:
```csharp
public class UnknownPropertyTypeModel
{
	public string Id { get; set; }
	public object UnknownItem { get; set; }
}
```

While the default serialization system can deserialize that to the type set in the discriminator, it does require that discriminator to be defined before hand. Effectively, this change allows the runtime discovery of these discriminators and processes them accordingly and through the MongoFramework entity mapping system.

With this in mind, it also will attempt to deserialize to a `Dictionary<string, object>` rather than an `ExpandoObject` where no discriminator is available. This behaviour is open for change in the future if required.