### PR TITLE
Use Microsoft.Bcl.AsyncInterfaces

### DIFF
--- a/src/MongoFramework/MongoFramework.csproj
+++ b/src/MongoFramework/MongoFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>MongoFramework</AssemblyName>
     <Title>MongoFramework</Title>
     <Description>An "Entity Framework"-like interface for the MongoDB C# Driver</Description>
@@ -13,7 +13,7 @@
     <PackageReference Include="MongoDB.Driver" Version="2.9.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/MongoFramework.Tests/MongoFramework.Tests.csproj
+++ b/tests/MongoFramework.Tests/MongoFramework.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It turns out we can keep the `netstandard2.0` support by adding `Microsoft.Bcl.AsyncInterfaces` which is where `IAsyncEnumerable<T>` lives.