### PR TITLE
Remove generic property from EntityEntry

### DIFF
--- a/src/MongoFramework/Infrastructure/Commands/AddEntityCommand.cs
+++ b/src/MongoFramework/Infrastructure/Commands/AddEntityCommand.cs
@@ -7,16 +7,16 @@ namespace MongoFramework.Infrastructure.Commands
 {
 	public class AddEntityCommand<TEntity> : IWriteCommand<TEntity> where TEntity : class
 	{
-		private EntityEntry<TEntity> EntityEntry { get; }
+		private EntityEntry EntityEntry { get; }
 
-		public AddEntityCommand(EntityEntry<TEntity> entityEntry)
+		public AddEntityCommand(EntityEntry entityEntry)
 		{
 			EntityEntry = entityEntry;
 		}
 
 		public IEnumerable<WriteModel<TEntity>> GetModel()
 		{
-			yield return new InsertOneModel<TEntity>(EntityEntry.Entity);
+			yield return new InsertOneModel<TEntity>(EntityEntry.Entity as TEntity);
 		}
 	}
 }

--- a/src/MongoFramework/Infrastructure/Commands/RemoveEntityCommand.cs
+++ b/src/MongoFramework/Infrastructure/Commands/RemoveEntityCommand.cs
@@ -9,9 +9,9 @@ namespace MongoFramework.Infrastructure.Commands
 {
 	public class RemoveEntityCommand<TEntity> : IWriteCommand<TEntity> where TEntity : class
 	{
-		private EntityEntry<TEntity> EntityEntry { get; }
+		private EntityEntry EntityEntry { get; }
 
-		public RemoveEntityCommand(EntityEntry<TEntity> entityEntry)
+		public RemoveEntityCommand(EntityEntry entityEntry)
 		{
 			EntityEntry = entityEntry;
 		}
@@ -19,7 +19,7 @@ namespace MongoFramework.Infrastructure.Commands
 		public IEnumerable<WriteModel<TEntity>> GetModel()
 		{
 			var definition = EntityMapping.GetOrCreateDefinition(typeof(TEntity));
-			yield return new DeleteOneModel<TEntity>(definition.CreateIdFilterFromEntity(EntityEntry.Entity));
+			yield return new DeleteOneModel<TEntity>(definition.CreateIdFilterFromEntity(EntityEntry.Entity as TEntity));
 		}
 	}
 }

--- a/src/MongoFramework/Infrastructure/Commands/UpdateEntityCommand.cs
+++ b/src/MongoFramework/Infrastructure/Commands/UpdateEntityCommand.cs
@@ -8,9 +8,9 @@ namespace MongoFramework.Infrastructure.Commands
 {
 	public class UpdateEntityCommand<TEntity> : IWriteCommand<TEntity> where TEntity : class
 	{
-		private EntityEntry<TEntity> EntityEntry { get; }
+		private EntityEntry EntityEntry { get; }
 
-		public UpdateEntityCommand(EntityEntry<TEntity> entityEntry)
+		public UpdateEntityCommand(EntityEntry entityEntry)
 		{
 			EntityEntry = entityEntry;
 		}
@@ -23,7 +23,7 @@ namespace MongoFramework.Infrastructure.Commands
 			{
 				var definition = EntityMapping.GetOrCreateDefinition(typeof(TEntity));
 				var updateDefintion = UpdateDefinitionHelper.CreateFromDiff<TEntity>(EntityEntry.OriginalValues, EntityEntry.CurrentValues);
-				yield return new UpdateOneModel<TEntity>(definition.CreateIdFilterFromEntity(EntityEntry.Entity), updateDefintion);
+				yield return new UpdateOneModel<TEntity>(definition.CreateIdFilterFromEntity(EntityEntry.Entity as TEntity), updateDefintion);
 			}
 		}
 	}

--- a/src/MongoFramework/Infrastructure/EntityCollection.cs
+++ b/src/MongoFramework/Infrastructure/EntityCollection.cs
@@ -8,7 +8,7 @@ namespace MongoFramework.Infrastructure
 {
 	public class EntityCollection<TEntity> : IEntityCollection<TEntity> where TEntity : class
 	{
-		protected List<EntityEntry<TEntity>> Entries { get; } = new List<EntityEntry<TEntity>>();
+		protected List<EntityEntry> Entries { get; } = new List<EntityEntry>();
 
 		private IEntityDefinition EntityDefinition { get; }
 
@@ -21,7 +21,7 @@ namespace MongoFramework.Infrastructure
 
 		public bool IsReadOnly => false;
 
-		public EntityEntry<TEntity> GetEntry(TEntity entity)
+		public EntityEntry GetEntry(TEntity entity)
 		{
 			var entityId = EntityDefinition.GetIdValue(entity);
 			var defaultIdValue = EntityDefinition.GetDefaultId();
@@ -45,7 +45,7 @@ namespace MongoFramework.Infrastructure
 			return null;
 		}
 
-		public IEnumerable<EntityEntry<TEntity>> GetEntries()
+		public IEnumerable<EntityEntry> GetEntries()
 		{
 			return Entries;
 		}
@@ -62,12 +62,12 @@ namespace MongoFramework.Infrastructure
 				else
 				{
 					Entries.Remove(entry);
-					Entries.Add(new EntityEntry<TEntity>(entity, state));
+					Entries.Add(new EntityEntry(entity, state));
 				}
 			}
 			else
 			{
-				Entries.Add(new EntityEntry<TEntity>(entity, state));
+				Entries.Add(new EntityEntry(entity, state));
 			}
 		}
 
@@ -120,7 +120,7 @@ namespace MongoFramework.Infrastructure
 
 			for (var i = 0; i < Count; i++)
 			{
-				array[i + arrayIndex] = Entries[i].Entity;
+				array[i + arrayIndex] = Entries[i].Entity as TEntity;
 			}
 		}
 
@@ -128,7 +128,7 @@ namespace MongoFramework.Infrastructure
 		{
 			foreach (var entry in GetEntries())
 			{
-				yield return entry.Entity;
+				yield return entry.Entity as TEntity;
 			}
 		}
 

--- a/src/MongoFramework/Infrastructure/EntityCommandBuilder.cs
+++ b/src/MongoFramework/Infrastructure/EntityCommandBuilder.cs
@@ -8,7 +8,7 @@ namespace MongoFramework.Infrastructure
 {
 	public static class EntityCommandBuilder<TEntity> where TEntity : class
 	{
-		public static IWriteCommand<TEntity> CreateCommand(EntityEntry<TEntity> entityEntry)
+		public static IWriteCommand<TEntity> CreateCommand(EntityEntry entityEntry)
 		{
 			if (entityEntry.State == EntityEntryState.Added)
 			{

--- a/src/MongoFramework/Infrastructure/EntityEntry.cs
+++ b/src/MongoFramework/Infrastructure/EntityEntry.cs
@@ -2,10 +2,10 @@
 
 namespace MongoFramework.Infrastructure
 {
-	public class EntityEntry<TEntity> where TEntity : class
+	public class EntityEntry
 	{
 		/// <summary>
-		/// The state of the entity in this <see cref="EntityEntry{TEntity}"/> object.
+		/// The state of the entity in this <see cref="EntityEntry"/> object.
 		/// </summary>
 		public EntityEntryState State { get; set; }
 
@@ -15,16 +15,16 @@ namespace MongoFramework.Infrastructure
 		public BsonDocument OriginalValues { get; private set; }
 
 		/// <summary>
-		/// The entity that forms this <see cref="EntityEntry{TEntity}"/> object.
+		/// The entity that forms this <see cref="EntityEntry"/> object.
 		/// </summary>
-		public TEntity Entity { get; private set; }
+		public object Entity { get; private set; }
 
 		/// <summary>
-		/// Creates a new <see cref="EntityEntry{TEntity}"/> with the specified entity and state information.
+		/// Creates a new <see cref="EntityEntry"/> with the specified entity and state information.
 		/// </summary>
 		/// <param name="entity"></param>
 		/// <param name="state"></param>
-		public EntityEntry(TEntity entity, EntityEntryState state)
+		public EntityEntry(object entity, EntityEntryState state)
 		{
 			State = state;
 			Entity = entity;
@@ -47,7 +47,7 @@ namespace MongoFramework.Infrastructure
 		/// Update the original values to reflect the state of the provided entity.
 		/// </summary>
 		/// <param name="entity"></param>
-		public void Refresh(TEntity entity)
+		public void Refresh(object entity)
 		{
 			OriginalValues = entity.ToBsonDocument();
 			State = this.HasChanges() ? EntityEntryState.Updated : EntityEntryState.NoChanges;

--- a/src/MongoFramework/Infrastructure/EntityEntryExtensions.cs
+++ b/src/MongoFramework/Infrastructure/EntityEntryExtensions.cs
@@ -8,7 +8,7 @@ namespace MongoFramework.Infrastructure
 		/// Whether there are any changes between the original and current values of the entity.
 		/// </summary>
 		/// <returns></returns>
-		public static bool HasChanges<TEntity>(this EntityEntry<TEntity> entry) where TEntity : class
+		public static bool HasChanges(this EntityEntry entry)
 		{
 			return BsonDiff.HasDifferences(entry.OriginalValues, entry.CurrentValues);
 		}

--- a/src/MongoFramework/Infrastructure/EntityWriterPipeline.cs
+++ b/src/MongoFramework/Infrastructure/EntityWriterPipeline.cs
@@ -90,7 +90,7 @@ namespace MongoFramework.Infrastructure
 					}
 					else if (entry.State == EntityEntryState.Deleted)
 					{
-						collection.Remove(entry.Entity);
+						collection.Remove(entry.Entity as TEntity);
 					}
 				}
 			}
@@ -106,11 +106,11 @@ namespace MongoFramework.Infrastructure
 				{
 					if (entry.State == EntityEntryState.Added)
 					{
-						EntityMutation<TEntity>.MutateEntity(entry.Entity, MutatorType.Insert, Connection);
+						EntityMutation<TEntity>.MutateEntity(entry.Entity as TEntity, MutatorType.Insert, Connection);
 					}
 					else if (entry.State == EntityEntryState.Updated)
 					{
-						EntityMutation<TEntity>.MutateEntity(entry.Entity, MutatorType.Update, Connection);
+						EntityMutation<TEntity>.MutateEntity(entry.Entity as TEntity, MutatorType.Update, Connection);
 					}
 
 					var validationContext = new ValidationContext(entry.Entity);

--- a/src/MongoFramework/Infrastructure/IEntityCollection.cs
+++ b/src/MongoFramework/Infrastructure/IEntityCollection.cs
@@ -4,8 +4,8 @@ namespace MongoFramework.Infrastructure
 {
 	public interface IEntityCollectionBase<TEntity> where TEntity : class
 	{
-		EntityEntry<TEntity> GetEntry(TEntity entity);
-		IEnumerable<EntityEntry<TEntity>> GetEntries();
+		EntityEntry GetEntry(TEntity entity);
+		IEnumerable<EntityEntry> GetEntries();
 		void Update(TEntity entity, EntityEntryState state);
 		bool Remove(TEntity entity);
 	}

--- a/tests/MongoFramework.Tests/Infrastructure/Commands/AddEntityCommandTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/Commands/AddEntityCommandTests.cs
@@ -31,7 +31,7 @@ namespace MongoFramework.Tests.Infrastructure.Commands
 
 			writer.Write(new[]
 			{
-				new AddEntityCommand<TestModel>(new EntityEntry<TestModel>(entity, EntityEntryState.Added))
+				new AddEntityCommand<TestModel>(new EntityEntry(entity, EntityEntryState.Added))
 			});
 
 			Assert.IsNotNull(entity.Id);

--- a/tests/MongoFramework.Tests/Infrastructure/Commands/RemoveEntityByIdCommandTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/Commands/RemoveEntityByIdCommandTests.cs
@@ -32,7 +32,7 @@ namespace MongoFramework.Tests.Infrastructure.Commands
 
 			writer.Write(new[]
 			{
-				new AddEntityCommand<TestModel>(new EntityEntry<TestModel>(entity, EntityEntryState.Added))
+				new AddEntityCommand<TestModel>(new EntityEntry(entity, EntityEntryState.Added))
 			});
 
 			writer.Write(new[]

--- a/tests/MongoFramework.Tests/Infrastructure/Commands/RemoveEntityCommandTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/Commands/RemoveEntityCommandTests.cs
@@ -32,12 +32,12 @@ namespace MongoFramework.Tests.Infrastructure.Commands
 
 			writer.Write(new[]
 			{
-				new AddEntityCommand<TestModel>(new EntityEntry<TestModel>(entity, EntityEntryState.Added))
+				new AddEntityCommand<TestModel>(new EntityEntry(entity, EntityEntryState.Added))
 			});
 
 			writer.Write(new[]
 			{
-				new RemoveEntityCommand<TestModel>(new EntityEntry<TestModel>(entity, EntityEntryState.Deleted))
+				new RemoveEntityCommand<TestModel>(new EntityEntry(entity, EntityEntryState.Deleted))
 			});
 
 			var dbEntity = reader.AsQueryable().Where(e => e.Id == entity.Id).FirstOrDefault();

--- a/tests/MongoFramework.Tests/Infrastructure/Commands/RemoveEntityRangeCommandTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/Commands/RemoveEntityRangeCommandTests.cs
@@ -42,8 +42,8 @@ namespace MongoFramework.Tests.Infrastructure.Commands
 
 			writer.Write(new[]
 			{
-				new AddEntityCommand<TestModel>(new EntityEntry<TestModel>(entities[0], EntityEntryState.Added)),
-				new AddEntityCommand<TestModel>(new EntityEntry<TestModel>(entities[1], EntityEntryState.Added))
+				new AddEntityCommand<TestModel>(new EntityEntry(entities[0], EntityEntryState.Added)),
+				new AddEntityCommand<TestModel>(new EntityEntry(entities[1], EntityEntryState.Added))
 			});
 
 			writer.Write(new[]

--- a/tests/MongoFramework.Tests/Infrastructure/Commands/UpdateEntityCommandTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/Commands/UpdateEntityCommandTests.cs
@@ -32,7 +32,7 @@ namespace MongoFramework.Tests.Infrastructure.Commands
 
 			writer.Write(new[]
 			{
-				new AddEntityCommand<TestModel>(new EntityEntry<TestModel>(entity, EntityEntryState.Added))
+				new AddEntityCommand<TestModel>(new EntityEntry(entity, EntityEntryState.Added))
 			});
 
 			var updatedEntity = new TestModel
@@ -43,7 +43,7 @@ namespace MongoFramework.Tests.Infrastructure.Commands
 
 			writer.Write(new[]
 			{
-				new UpdateEntityCommand<TestModel>(new EntityEntry<TestModel>(updatedEntity, EntityEntryState.Updated))
+				new UpdateEntityCommand<TestModel>(new EntityEntry(updatedEntity, EntityEntryState.Updated))
 			});
 
 			var dbEntity = reader.AsQueryable().Where(e => e.Id == entity.Id).FirstOrDefault();

--- a/tests/MongoFramework.Tests/Infrastructure/EntityCollectionTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/EntityCollectionTests.cs
@@ -69,7 +69,7 @@ namespace MongoFramework.Tests.Infrastructure
 			entityCollection.Update(updatedEntity, EntityEntryState.Updated);
 			Assert.IsFalse(entityCollection.GetEntries().Any(e => e.Entity == entity));
 			Assert.IsTrue(entityCollection.GetEntries()
-				.Any(e => e.Entity == updatedEntity && e.Entity.Title == "DbEntityCollectionTests.UpdateExistingEntryWithId-2"));
+				.Any(e => e.Entity == updatedEntity && (e.Entity as EntityCollectionModel).Title == "DbEntityCollectionTests.UpdateExistingEntryWithId-2"));
 		}
 
 		[TestMethod]

--- a/tests/MongoFramework.Tests/Infrastructure/EntityWriterPipelineTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/EntityWriterPipelineTests.cs
@@ -79,7 +79,7 @@ namespace MongoFramework.Tests.Infrastructure
 				Title = "EntityWriterPipelineTests.WriteFromCollection"
 			};
 			var command = EntityCommandBuilder<TestModel>.CreateCommand(
-				new EntityEntry<TestModel>(entity, EntityEntryState.Added)
+				new EntityEntry(entity, EntityEntryState.Added)
 			);
 
 			pipeline.StageCommand(command);

--- a/tests/MongoFramework.Tests/Infrastructure/Linq/Processors/EntityTrackingProcessorTests.cs
+++ b/tests/MongoFramework.Tests/Infrastructure/Linq/Processors/EntityTrackingProcessorTests.cs
@@ -26,7 +26,7 @@ namespace MongoFramework.Tests.Infrastructure.Linq.Processors
 
 			processor.ProcessEntity(new TestEntity { Id = "123", Description = "Database" }, null);
 
-			var collectionEntity = collection.GetEntry(new TestEntity { Id = "123" }).Entity;
+			var collectionEntity = collection.GetEntry(new TestEntity { Id = "123" }).Entity as TestEntity;
 			Assert.AreEqual("Database", collectionEntity.Description);
 		}
 
@@ -44,7 +44,7 @@ namespace MongoFramework.Tests.Infrastructure.Linq.Processors
 
 			processor.ProcessEntity(new TestEntity { Id = "123", Description = "2" }, null);
 
-			var collectionEntity = collection.GetEntry(new TestEntity { Id = "123" }).Entity;
+			var collectionEntity = collection.GetEntry(new TestEntity { Id = "123" }).Entity as TestEntity;
 			Assert.AreEqual("2", collectionEntity.Description);
 		}
 
@@ -62,7 +62,7 @@ namespace MongoFramework.Tests.Infrastructure.Linq.Processors
 
 			processor.ProcessEntity(new TestEntity { Id = "123", Description = "Database" }, null);
 
-			var collectionEntity = collection.GetEntry(new TestEntity { Id = "123" }).Entity;
+			var collectionEntity = collection.GetEntry(new TestEntity { Id = "123" }).Entity as TestEntity;
 			Assert.AreEqual("Deleted", collectionEntity.Description);
 		}
 
@@ -80,7 +80,7 @@ namespace MongoFramework.Tests.Infrastructure.Linq.Processors
 
 			processor.ProcessEntity(new TestEntity { Id = "123", Description = "Database" }, null);
 
-			var collectionEntity = collection.GetEntry(new TestEntity { Id = "123" }).Entity;
+			var collectionEntity = collection.GetEntry(new TestEntity { Id = "123" }).Entity as TestEntity;
 			Assert.AreEqual("Updated", collectionEntity.Description);
 		}
 
@@ -98,7 +98,7 @@ namespace MongoFramework.Tests.Infrastructure.Linq.Processors
 
 			processor.ProcessEntity(new TestEntity { Id = "123", Description = "Database" }, null);
 
-			var collectionEntity = collection.GetEntry(new TestEntity { Id = "123" }).Entity;
+			var collectionEntity = collection.GetEntry(new TestEntity { Id = "123" }).Entity as TestEntity;
 			Assert.AreEqual("Added", collectionEntity.Description);
 		}
 	}


### PR DESCRIPTION
This helps pave the way for a single entity collection inside the context rather than per MongoDbSet