### PR TITLE
Return existing DbSet

### DIFF
--- a/src/MongoFramework/MongoDbContext.cs
+++ b/src/MongoFramework/MongoDbContext.cs
@@ -1,4 +1,4 @@
-﻿using MongoFramework.Infrastructure;
+using MongoFramework.Infrastructure;
 using MongoFramework.Infrastructure.Commands;
 using MongoFramework.Infrastructure.Indexing;
 using MongoFramework.Infrastructure.Internal;
@@ -115,6 +115,14 @@ namespace MongoFramework
 
 		public virtual IMongoDbSet<TEntity> Set<TEntity>() where TEntity : class
 		{
+			var properties = DbSetInitializer.GetDbSetProperties(this);
+			var existing = properties.FirstOrDefault(p => p.PropertyType.GenericTypeArguments[0] == typeof(TEntity));
+
+			if (existing != null)
+			{
+				return existing.GetValue(this) as IMongoDbSet<TEntity>;
+			}
+
 			return new MongoDbSet<TEntity>(this);
 		}
 

--- a/tests/MongoFramework.Tests/MongoDbContextTenantTests.cs
+++ b/tests/MongoFramework.Tests/MongoDbContextTenantTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MongoFramework.Attributes;
 using System;
 using System.Linq;
@@ -22,6 +22,11 @@ namespace MongoFramework.Tests
 		{
 			public string Label { get; set; }
 			public DateTime Date { get; set; }
+		}
+
+		class SecondModel
+		{
+			public string Id { get; set; }
 		}
 
 		class MongoDbContextTestContext : MongoDbTenantContext
@@ -60,6 +65,24 @@ namespace MongoFramework.Tests
 			using (var context = new MongoDbContextTestContext(TestConfiguration.GetConnection(), TestConfiguration.GetTenantId()))
 			{
 				Assert.AreEqual(5, context.DbBucketSet.BucketSize);
+			}
+		}
+
+		[TestMethod]
+		public void GenericSetReturnsCorrectSet()
+		{
+			using (var context = new MongoDbContextTestContext(TestConfiguration.GetConnection(), TestConfiguration.GetTenantId()))
+			{
+				Assert.IsInstanceOfType(context.Set<DbSetModel>(),typeof(MongoDbTenantSet<DbSetModel>));
+			}
+		}
+
+		[TestMethod]
+		public void GenericSetReturnsNewSet()
+		{
+			using (var context = new MongoDbContextTestContext(TestConfiguration.GetConnection(), TestConfiguration.GetTenantId()))
+			{
+				Assert.IsInstanceOfType(context.Set<SecondModel>(),typeof(MongoDbSet<SecondModel>));
 			}
 		}
 


### PR DESCRIPTION
Solves #177 by returning an existing DbSet if it exists on the Context, otherwise return new one as before.