### PR TITLE
Change private Url setter to protected

### DIFF
--- a/src/MongoFramework/MongoDbConnection.cs
+++ b/src/MongoFramework/MongoDbConnection.cs
@@ -9,7 +9,7 @@ namespace MongoFramework
 {
 	public class MongoDbConnection : IMongoDbConnection
 	{
-		public MongoUrl Url { get; private set; }
+		public MongoUrl Url { get; protected set; }
 		private bool IsDisposed { get; set; }
 
 		private IMongoClient InternalClient;


### PR DESCRIPTION
Allow for clean inheritance for DI use

Creating a MongoDbConnection that will take a tenant by DI and use its connection string.  I'd rather be able to inherit from the existing MongoDbConnection than copy the whole class for this project.

If its OK with you, would you merge and update NuGet with a tiny release 0.23.1 perhaps?