### PR TITLE
Fix incorrect key lookup on WhereIdMatches

### DIFF
--- a/src/MongoFramework/Infrastructure/Commands/AddToBucketCommand.cs
+++ b/src/MongoFramework/Infrastructure/Commands/AddToBucketCommand.cs
@@ -42,7 +42,7 @@ namespace MongoFramework.Infrastructure.Commands
 				.Min(b => b.Min, itemTimeValue)
 				.Max(b => b.Max, itemTimeValue)
 				.SetOnInsert(b => b.BucketSize, BucketSize)
-				.SetOnInsert(b => b.Id, entityDefinition.Key.KeyGenerator.Generate());
+				.SetOnInsert(b => b.Id, entityDefinition.FindNearestKey().KeyGenerator.Generate());
 
 			yield return new UpdateOneModel<EntityBucket<TGroup, TSubEntity>>(filter, updateDefinition)
 			{

--- a/src/MongoFramework/Infrastructure/Mapping/EntityDefinitionExtensions.cs
+++ b/src/MongoFramework/Infrastructure/Mapping/EntityDefinitionExtensions.cs
@@ -6,14 +6,24 @@ namespace MongoFramework.Infrastructure.Mapping
 {
 	public static class EntityDefinitionExtensions
 	{
-		public static PropertyDefinition GetIdProperty(this EntityDefinition definition)
+		/// <summary>
+		/// Finds the nearest <see cref="KeyDefinition"/> from <paramref name="definition"/>, recursively searching the base <see cref="EntityDefinition"/> if one exists.
+		/// </summary>
+		/// <param name="definition">The <see cref="EntityDefinition"/> to start the search from.</param>
+		/// <returns>The key definition; otherwise <see langword="null"/> if one can not be found.</returns>
+		public static KeyDefinition FindNearestKey(this EntityDefinition definition)
 		{
 			if (definition.Key is null)
 			{
-				return EntityMapping.GetOrCreateDefinition(definition.EntityType.BaseType).GetIdProperty();
+				return EntityMapping.GetOrCreateDefinition(definition.EntityType.BaseType).FindNearestKey();
 			}
 
-			return definition.Key?.Property;
+			return definition.Key;
+		}
+
+		public static PropertyDefinition GetIdProperty(this EntityDefinition definition)
+		{
+			return definition.FindNearestKey()?.Property;
 		}
 
 		public static string GetIdName(this EntityDefinition definition)

--- a/src/MongoFramework/Linq/LinqExtensions.cs
+++ b/src/MongoFramework/Linq/LinqExtensions.cs
@@ -27,7 +27,8 @@ namespace MongoFramework.Linq
 
 		public static IQueryable<TEntity> WhereIdMatches<TEntity>(this IQueryable<TEntity> queryable, IEnumerable entityIds) where TEntity : class
 		{
-			var idProperty = EntityMapping.GetOrCreateDefinition(typeof(TEntity)).Key.Property;
+			var idProperty = EntityMapping.GetOrCreateDefinition(typeof(TEntity)).GetIdProperty()
+				?? throw new ArgumentException($"No Id property was found on entity type {typeof(TEntity)} or any base types");
 			return queryable.WherePropertyMatches(idProperty, entityIds);
 		}
 


### PR DESCRIPTION
With the new mapping change, the Id was looked up only on the specific entity definition, not any parent definitions. This would cause problems with derived types.