### PR TITLE
Improve change tracking performance

### DIFF
--- a/src/MongoFramework/Infrastructure/EntityEntryContainer.cs
+++ b/src/MongoFramework/Infrastructure/EntityEntryContainer.cs
@@ -46,11 +46,15 @@ namespace MongoFramework.Infrastructure
 				var entityDefinition = EntityMapping.GetOrCreateDefinition(collectionType);
 				var entityId = entityDefinition.GetIdValue(entity);
 				var defaultIdValue = entityDefinition.GetDefaultId();
+				var isDefaultId = Equals(entityId, defaultIdValue);
 				foreach (var entry in entries)
 				{
-					if (Equals(entityId, defaultIdValue) && ReferenceEquals(entry.Entity, entity))
+					if (isDefaultId)
 					{
-						return entry;
+						if (ReferenceEquals(entry.Entity, entity))
+						{
+							return entry;
+						}
 					}
 					else
 					{

--- a/tests/MongoFramework.Benchmarks/EntityCollectionGetEntryBenchmark.cs
+++ b/tests/MongoFramework.Benchmarks/EntityCollectionGetEntryBenchmark.cs
@@ -1,0 +1,40 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using MongoFramework.Infrastructure;
+
+namespace MongoFramework.Benchmarks;
+
+[SimpleJob(RuntimeMoniker.Net60), MemoryDiagnoser]
+public class EntityEntryContainerBenchmark
+{
+	[Params(100, 1_000, 10_000)]
+	public int EntryCount;
+
+	private EntityEntryContainer Container;
+	private TestEntity[] Entities;
+
+	private class TestEntity
+	{
+		public string Id { get; set; }
+	}
+
+	[GlobalSetup]
+	public void Setup()
+	{
+		Container = new EntityEntryContainer();
+		Entities = new TestEntity[EntryCount];
+		for (var i = 0; i < Entities.Length; i++)
+		{
+			Entities[i] = new TestEntity();
+		}
+	}
+
+	[Benchmark]
+	public void SetEntityState()
+	{
+		for (var i = 0; i < Entities.Length; i++)
+		{
+			Container.SetEntityState(Entities[i], EntityEntryState.Added);
+		}
+	}
+}


### PR DESCRIPTION
Fixes #362

When adding a very large number of entities to the change tracker, it was performing an extreme number of calls to `GetValue` on the `PropertyInfo`. This isn't typically slow but is very slow when call as often as it was.

This PR contains two primary changes to improve the performance of the existing code
- Slight change in `GetEntry` lookups to avoid calling `GetIdValue` unnecessarily
- Dynamically generate a delegate for the internal mechanism of `GetIdValue`

-----

Up to 98% faster for setting the entity state.

**Before**

|         Method | EntryCount |           Mean |        Error |       StdDev | Allocated |
|--------------- |----------- |---------------:|-------------:|-------------:|----------:|
| SetEntityState |        100 |       352.7 us |      6.66 us |      6.84 us |       2 B |
| SetEntityState |       1000 |    32,571.1 us |    161.22 us |    134.62 us |      30 B |
| SetEntityState |      10000 | 3,402,924.9 us | 45,554.20 us | 40,382.61 us |    3656 B |

**After**

|         Method | EntryCount |         Mean |        Error |       StdDev | Allocated |
|--------------- |----------- |-------------:|-------------:|-------------:|----------:|
| SetEntityState |        100 |     22.62 us |     0.450 us |     0.645 us |         - |
| SetEntityState |       1000 |    911.66 us |    17.737 us |    18.979 us |       1 B |
| SetEntityState |      10000 | 82,002.73 us | 1,611.556 us | 3,104.921 us |      69 B |